### PR TITLE
add `set-election-managers` to set roles that can manage elections

### DIFF
--- a/src/cogs/voting.py
+++ b/src/cogs/voting.py
@@ -21,7 +21,6 @@ class Voting(commands.Cog):
         self.bot = bot
 
     @commands.command(name="start-election", help="Start an election in current server.")
-    @commands.has_guild_permissions(manage_guild=True)
     @commands.guild_only()
     async def start_election(self, ctx, *, candidates):
         """
@@ -29,6 +28,9 @@ class Voting(commands.Cog):
         Args: list of mentions separated by a space.
         Return value: None
         """
+        has_permission = await helpers.is_election_manager(ctx)
+        if not has_permission:
+            raise commands.errors.CheckFailure(message="You are not an election manager.")
         server = await ServersSettings.filter(server_id=ctx.guild.id).first()
         if not server:
             raise commands.errors.CommandError("Set reward roles first.")
@@ -89,7 +91,6 @@ class Voting(commands.Cog):
     @commands.command(
         name="view-current-elections", help="View which elections are ongoing in this server."
     )
-    @commands.has_guild_permissions(manage_guild=True)
     @commands.guild_only()
     async def view_current_elections(self, ctx):
         """
@@ -97,6 +98,9 @@ class Voting(commands.Cog):
         Args: none except context
         Return value: None
         """
+        has_permission = await helpers.is_election_manager(ctx)
+        if not has_permission:
+            raise commands.errors.CheckFailure(message="You are not an election manager.")
         elections = list(await Elections.filter(server_id=ctx.guild.id).all())
         embed = discord.Embed(
             title="Ongoing elections",
@@ -117,7 +121,6 @@ class Voting(commands.Cog):
         await ctx.reply(f"{error}")
 
     @commands.command(name="view-election-poll", help="View the current polls for an election.")
-    @commands.has_guild_permissions(manage_guild=True)
     @commands.guild_only()
     async def view_election_poll(self, ctx, *, election_id):
         """
@@ -125,6 +128,9 @@ class Voting(commands.Cog):
         Args: election_id as type integer
         Return value: None
         """
+        has_permission = await helpers.is_election_manager(ctx)
+        if not has_permission:
+            raise commands.errors.CheckFailure(message="You are not an election manager.")
         try:
             election = await Elections.filter(id=election_id).first()
         except Exception:
@@ -163,7 +169,6 @@ class Voting(commands.Cog):
     @commands.command(
         name="finish-election", help="Finish an election and give out the roles to the winners."
     )
-    @commands.has_guild_permissions(manage_guild=True)
     @commands.guild_only()
     async def finish_election(self, ctx, *, election_id):
         """
@@ -171,6 +176,9 @@ class Voting(commands.Cog):
         Args: election ID as type int.
         Return value: None.
         """
+        has_permission = await helpers.is_election_manager(ctx)
+        if not has_permission:
+            raise commands.errors.CheckFailure(message="You are not an election manager.")
         server = await ServersSettings.filter(
             server_id=ctx.guild.id
         ).first()  # assuming it exists, one can't start an election without that

--- a/src/db/db.py
+++ b/src/db/db.py
@@ -17,6 +17,7 @@ class ServersSettings(Model):
     role_weights = fields.JSONField(null=True) # dict: {role_id: integer_weight}
     winners_pool = fields.IntField(default=1)
     prefixes = fields.TextField(default="!")
+    election_managers = fields.TextField(default="")
 
     def __str__(self):
         """

--- a/src/events.py
+++ b/src/events.py
@@ -39,6 +39,8 @@ async def on_guild_join(guild):
     guild_timestamp = datetime.datetime.now()
     server = await ServersSettings.create(server_id=guild.id)
     server.prefixes = internals.DEFAULT_PREFIX
+    managers = [str(i.id) for i in guild.roles if i.permissions.manage_guild]
+    server.election_managers = ",".join(managers)
     await server.save()
     await guild.get_member(internals.bot.user.id).edit(nick=f"[{internals.DEFAULT_PREFIX}]{internals.bot.user.name}")
     print(f"Joined server {guild.name} (id: {guild.id}) at ({guild_timestamp})")
@@ -78,4 +80,5 @@ async def on_command_error(ctx, error):
         return
     else:
         await ctx.reply(f"{error}")
+        print(error)
         return

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -7,6 +7,8 @@ from discord.ext import commands
 
 import src.internals as internals
 
+from src.db.db import ServersSettings
+
 
 async def get_id_by_mention(mention: str) -> int:
     """
@@ -93,3 +95,11 @@ async def get_emoji_id_from_embed_field(field: str) -> int:
     emoji_data = field[: field.find(">")][2:]
     emoji_id = int(emoji_data[emoji_data.find(":") + 1 :])
     return emoji_id
+
+async def is_election_manager(ctx) -> bool:
+    server = await ServersSettings(server_id=ctx.guild.id).first()
+    managers = set([int(i) for i in server.election_managers.split(",")])
+    author_roles = set([i.id for i in ctx.author.roles])
+    if not author_roles.intersection(managers):
+        return False
+    return True


### PR DESCRIPTION
# Changes
* Changed database schema to store election manager roles as a string of integer ids separated by commas.
* Added `set-election-managers` to add new roles to election manager roles.
* Changed `on_guild_join` to set all roles with `manage_guild` permission as election managers when joining a Discord server.
* Added a helper function `is_election_manager` to check whether a user has any role that is set to be an election manager.
* Changed all election-related commands to check election management permissions via `is_election_manager`.