### PR TITLE
Fix voting reaction listeners

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,5 @@ dmypy.json
 
 # Project specific files
 db.sqlite3
+db.sqlite3-shm
+db.sqlite3-wal


### PR DESCRIPTION
# Changes
* Added back the `operator` import that I somewhat forgot... oops.
* Added fetching the action initiator member via `discord.utils.get` to `on_raw_reaction_remove` since `payload.member` is only available in `on_raw_reaction_add` **for some reason**.
* Added a check to assure the candidate cannot vote for themselves.