### PR TITLE
Move DB connection/disconnection logic

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,4 @@ import src.db.db as db
 import src.events as events  # do not touch, removing this import disables the events defined in that file
 import src.internals as internals
 
-asyncio.run(internals.init_db())
-
 internals.bot.run(internals.TOKEN)

--- a/src/cogs/god.py
+++ b/src/cogs/god.py
@@ -21,9 +21,7 @@ class God(commands.Cog):
         Args: None except context
         Return value: None
         """
-        await db.db_cleanup()
         god = (await self.bot.application_info()).owner
-        await god.send("Exiting...")
         await self.bot.close()
         print(f"Successfully caught fire via override from {god}.")
 

--- a/src/db/db.py
+++ b/src/db/db.py
@@ -9,17 +9,6 @@ from dotenv import load_dotenv
 from tortoise import Tortoise, fields, run_async
 from tortoise.models import Model
 
-load_dotenv()
-DEPRECATED = False
-DATABASE_URL = os.getenv("DATABASE_URL") if os.getenv("DATABASE_URL") else None
-LOCAL_DB = bool(os.getenv("LOCAL_DB")) if os.getenv("LOCAL_DB") else True
-DRIVER = "sqlite" if DEPRECATED else "postgres"
-POSTGRES_USERNAME = os.getenv("POSTGRES_USERNAME") if not LOCAL_DB else "postgres"
-POSTGRES_HOST = os.getenv("POSTGRES_HOST") if not LOCAL_DB else "localhost"
-POSTGRES_PORT = os.getenv("POSTGRES_PORT") if not LOCAL_DB else 5432
-POSTGRES_DBNAME = os.getenv("POSTGRES_DBNAME") if not LOCAL_DB else "postgres"
-POSTGRES_PASSWORD = os.getenv("POSTGRES_PASSWORD") if not LOCAL_DB else ""
-
 class ServersSettings(Model):
     """
     Model for server-wide settings storage.
@@ -67,43 +56,27 @@ class Elections(Model):
         table_description = "Stores individual election instances"
 
 
-async def init(in_memory=False):
+async def init():
     """
     Start up the database connections.
     """
-    config_dict = []
-    if deprecated:
-        if in_memory:
-            warnings.warn("in_memory is deprecated. This will have no effect on the postgres driver and will be removed in the next release.", DeprecationWarning)
-            database_path = f"{DRIVER}://:memory:"
-        else:
-            database_path = f"{DRIVER}://{os.path.dirname(os.path.realpath(__file__))}/../../db.sqlite3"
-        await Tortoise.init(
-            db_url=database_path,
-            modules={"models": [f"{__name__}"]},
-            )
-        await Tortoise.generate_schemas(safe=True)
+    load_dotenv()
+    DATABASE_URL = os.getenv("DATABASE_URL") if os.getenv("DATABASE_URL") else None
+    LOCAL_DB = bool(int(os.getenv("LOCAL_DB"))) if os.getenv("LOCAL_DB") else True
+    POSTGRES_USERNAME = os.getenv("POSTGRES_USERNAME") if not LOCAL_DB else "postgres"
+    POSTGRES_HOST = os.getenv("POSTGRES_HOST") if not LOCAL_DB else "localhost"
+    POSTGRES_PORT = os.getenv("POSTGRES_PORT") if not LOCAL_DB else 5432
+    POSTGRES_DBNAME = os.getenv("POSTGRES_DBNAME") if not LOCAL_DB else "postgres"
+    POSTGRES_PASSWORD = os.getenv("POSTGRES_PASSWORD") if not LOCAL_DB else ""
+    if DATABASE_URL:
+        database_path = DATABASE_URL
     else:
-        if in_memory:
-            warnings.warn("in_memory is deprecated. This will have no effect on the postgres driver and will be removed in the next release.", DeprecationWarning)
-            warnings.warn("Reverting to SQLite driver.")
-            DRIVER = "sqlite"
-            database_path = f"{DRIVER}://:memory:" # revert to previous behaviour
-            await Tortoise.init(
-                db_url=database_path,
-                modules={"models": [f"{__name__}"]},
-                )
-            await Tortoise.generate_schemas(safe=True)
-        else:
-            if DATABASE_URL:
-                database_path = DATABASE_URL
-            else:
-                database_path = f"{DRIVER}://{POSTGRES_USERNAME}:{POSTGRES_PASSWORD}@{POSTGRES_HOST}:{POSTGRES_PORT}/{POSTGRES_DBNAME}"
-            await Tortoise.init(
-                db_url=database_path,
-                modules={"models": [f"{__name__}"]},
-                )
-            await Tortoise.generate_schemas(safe=True)
+        database_path = f"postgres://{POSTGRES_USERNAME}:{POSTGRES_PASSWORD}@{POSTGRES_HOST}:{POSTGRES_PORT}/{POSTGRES_DBNAME}"
+    await Tortoise.init(
+        db_url=database_path,
+        modules={"models": [f"{__name__}"]},
+        )
+    await Tortoise.generate_schemas(safe=True)
 
 
 async def db_cleanup():

--- a/src/events.py
+++ b/src/events.py
@@ -21,6 +21,9 @@ async def on_ready():
     await internals.bot.change_presence(
         activity=discord.Activity(type=discord.ActivityType.playing, name="election fraud")  # ha!
     )
+    print("Initializing database connection...")
+    await db.init()
+    print("Initialized!")
     start_timestamp = datetime.datetime.now()
     print(f"Bot ready at: {start_timestamp}")
     for guild in internals.bot.guilds:
@@ -28,6 +31,16 @@ async def on_ready():
         print(
             f"{internals.bot.user} is connected to {guild.name} (id: {guild.id}) at {guild_timestamp}"
         )
+
+@internals.bot.event
+async def on_disconnect():
+    """
+    Clean up on disconnect
+    Args: None
+    Return value: None
+    """
+    print("Disconnected from Discord, cleaning up DB connection...")
+    await db.db_cleanup()
 
 @internals.bot.event
 async def on_guild_join(guild):

--- a/src/internals.py
+++ b/src/internals.py
@@ -20,14 +20,6 @@ TOKEN = os.getenv("BOT_TOKEN")  # because, you know, it's supposed to be *secret
 IN_MEMORY_DB = os.getenv("IN_MEMORY_DB")  # whether we store the database in memory or in a file
 DEFAULT_PREFIX = "!"
 
-async def init_db():
-    """
-    Initialize database connection.
-    Args: none
-    Return value: None
-    """
-    await db.init()
-
 async def get_prefix(bot: commands.bot, message: tp.Any) -> tp.Any:
     """
     Get the bot prefix.

--- a/src/internals.py
+++ b/src/internals.py
@@ -26,7 +26,7 @@ async def init_db():
     Args: none
     Return value: None
     """
-    await db.init(in_memory=bool(IN_MEMORY_DB))
+    await db.init()
 
 async def get_prefix(bot: commands.bot, message: tp.Any) -> tp.Any:
     """


### PR DESCRIPTION
# Changes
* Removed `asyncio.run(internals.init_db())` from `main.py` since this created an extraneous `asyncio` loop that interfered with `bot.run()`.
* Removed `internals.init_db()` since it is not needed anymore.
* Moved `await db.init()` to `on_ready()` since this fixed the `asyncio` loop closed `RuntimeError`.
* Moved `await db.db_cleanup()` to a new `on_disconnect()` handler.
* Removed deprecated SQLite database logic, postgres is now the only DB supported.
* Moved envvars reading to `db.init()`.
* Removed `IN_MEMORY` envvar since postgres does not support this.